### PR TITLE
Store domain names and give a chance to show survey

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -11,6 +11,7 @@ port.onMessage.addListener(function(m) {
         // send Telemetry only accepts strings...
         payload = {
           PAGE_RELOADED: "true",
+          HOSTNAME: location.hostname,
           TIME_TO_DOM_CONTENT_LOADED_START_MS: entry.domContentLoadedEventStart.toString(),
           TIME_TO_DOM_COMPLETE_MS: entry.domComplete.toString(),
           TIME_TO_DOM_INTERACTIVE_MS: entry.domInteractive.toString(),
@@ -26,6 +27,7 @@ port.onMessage.addListener(function(m) {
       } else {
         payload = {
           PAGE_RELOADED: "false",
+          HOSTNAME: location.hostname,
           TIME_TO_DOM_CONTENT_LOADED_START_MS: entry.domContentLoadedEventStart.toString(),
           TIME_TO_DOM_COMPLETE_MS: entry.domComplete.toString(),
           TIME_TO_DOM_INTERACTIVE_MS: entry.domInteractive.toString(),


### PR DESCRIPTION
Store domain name and count of refresh times per domain. increment likelihood of popup showing as refresh count rises.

TODO: don't store domain name - instead store etld+1 generated id