### PR TITLE
Switch to per-tab tracking (fixes #18)

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,46 +1,25 @@
 let port = browser.runtime.connect();
 
-port.onMessage.addListener(function(m) {
-  if (m.message === "navigation") {
-    let perfEntries = performance.getEntriesByType("navigation");
-    // there *should* be only one entry - I haven't see anything to the alternative yet
-    for (const entry of perfEntries) {
-      let payload;
-      if (entry.type === "reload") {
-        // get the data from content, since it is more reliable
-        // send Telemetry only accepts strings...
-        payload = {
-          PAGE_RELOADED: "true",
-          etld: location.hostname,
-          TIME_TO_DOM_CONTENT_LOADED_START_MS: entry.domContentLoadedEventStart.toString(),
-          TIME_TO_DOM_COMPLETE_MS: entry.domComplete.toString(),
-          TIME_TO_DOM_INTERACTIVE_MS: entry.domInteractive.toString(),
-          TIME_TO_LOAD_EVENT_START_MS: entry.loadEventStart.toString(),
-          TIME_TO_LOAD_EVENT_END_MS: entry.loadEventEnd.toString(),
-          TIME_TO_RESPONSE_START_MS: entry.responseStart.toString(),
-          // Missing:
-          // TIME_TO_NON_BLANK_PAINT_MS ( integer)
-          // TIME_TO_DOM_LOADING_MS ( integer)
-          // TIME_TO_FIRST_INTERACTION_MS ( integer)
-        };
-        port.postMessage({message: "reload", payload, etld: location.hostname});
-      } else {
-        payload = {
-          PAGE_RELOADED: "false",
-          TIME_TO_DOM_CONTENT_LOADED_START_MS: entry.domContentLoadedEventStart.toString(),
-          TIME_TO_DOM_COMPLETE_MS: entry.domComplete.toString(),
-          TIME_TO_DOM_INTERACTIVE_MS: entry.domInteractive.toString(),
-          TIME_TO_LOAD_EVENT_START_MS: entry.loadEventStart.toString(),
-          TIME_TO_LOAD_EVENT_END_MS: entry.loadEventEnd.toString(),
-          TIME_TO_RESPONSE_START_MS: entry.responseStart.toString(),
-          // Missing:
-          // TIME_TO_NON_BLANK_PAINT_MS ( integer)
-          // TIME_TO_DOM_LOADING_MS ( integer)
-          // TIME_TO_FIRST_INTERACTION_MS ( integer)
-        };
-        port.postMessage({message: "navigate", payload, etld: location.hostname});
-      }
-    }
-  }
-});
+window.addEventListener("load", function() {
+  // there *should* be only one entry - I haven't see anything to the alternative yet
+  let entry = performance.getEntriesByType("navigation")[0];
 
+  let data = {
+    pageReloaded: entry.type == "reload",
+    etld: location.hostname,
+    performanceEvents: {
+      TIME_TO_DOM_CONTENT_LOADED_START_MS: entry.domContentLoadedEventStart.toString(),
+      TIME_TO_DOM_COMPLETE_MS: entry.domComplete,
+      TIME_TO_DOM_INTERACTIVE_MS: entry.domInteractive,
+      TIME_TO_LOAD_EVENT_START_MS: entry.loadEventStart,
+      TIME_TO_LOAD_EVENT_END_MS: entry.loadEventEnd,
+      TIME_TO_RESPONSE_START_MS: entry.responseStart,
+    },
+    // Missing:
+    // TIME_TO_NON_BLANK_PAINT_MS ( integer)
+    // TIME_TO_DOM_LOADING_MS ( integer)
+    // TIME_TO_FIRST_INTERACTION_MS ( integer)
+  };
+
+  port.postMessage({message: "contentInfo", data});
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -57,7 +57,7 @@
   ],
   "permissions": ["management", "storage", "alarms", "webNavigation"],
   "background": {
-    "scripts": ["studySetup.js", "feature.js", "background.js"]
+    "scripts": ["studySetup.js", "feature.js", "background.js", "tabs.js"]
   },
   "content_scripts": [
     {

--- a/src/privileged/notificationBar/schema.json
+++ b/src/privileged/notificationBar/schema.json
@@ -14,22 +14,20 @@
     ],
     "events": [
       {
-        "name": "onSurveyShown",
-        "type": "function",
-        "description": "The survey has been shown to the user.",
-        "parameters": []
-      },
-      {
         "name": "onReportPageBroken",
         "type": "function",
         "description": "The user clicked 'yes', this page was broken.",
-        "parameters": []
+        "parameters": [
+          {"type": "integer", "name": "tabId", "minimum": 0}
+        ]
       },
       {
         "name": "onReportPageNotBroken",
         "type": "function",
         "description": "The user clicked 'no', this page was not broken.",
-        "parameters": []
+        "parameters": [
+          {"type": "integer", "name": "tabId", "minimum": 0}
+        ]
       }
     ]
   }

--- a/src/privileged/trackers/framescript.js
+++ b/src/privileged/trackers/framescript.js
@@ -3,7 +3,9 @@ const {classes: Cc, interfaces: Ci} = Components;
 const trackerListener = {
   QueryInterface: XPCOMUtils.generateQI(["nsIWebProgressListener", "nsISupportsWeakReference"]),
   onLocationChange: function(progress, request, uri, flag) {
-    sendAsyncMessage("locationChange");
+    if (progress.isTopLevel) {
+      sendAsyncMessage("locationChange");
+    }
   },
   // Is it possible to get this message more than once per page?
   onSecurityChange: function(webProgress, request, state) {

--- a/src/privileged/trackers/schema.json
+++ b/src/privileged/trackers/schema.json
@@ -16,13 +16,17 @@
         "name": "onRecordTrackers",
         "type": "function",
         "description": "There is at least one tracker on this site.",
-        "parameters": []
+        "parameters": [
+          {"type": "integer", "name": "tabId", "minimum": 0}
+        ]
       },
       {
         "name": "onLocationChanged",
         "type": "function",
         "description": "The location changed",
-        "parameters": []
+        "parameters": [
+          {"type": "integer", "name": "tabId", "minimum": 0}
+        ]
       }
     ]
   }

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -1,0 +1,62 @@
+/**
+ * A helper object to make it easier to store and retrieve information
+ * about a specific tab, such as telemetry payload or how many times it was reloaded.
+ */
+window.TabRecords = {
+  _tabs: new Map(),
+
+  resetPayload(tabId) {
+    let tabInfo = this._tabs.get(tabId);
+    tabInfo.telemetryPayload = {
+      etld: null,
+      num_blockable_trackers: 0,
+      num_trackers_blocked: 0,
+      TIME_TO_DOM_CONTENT_LOADED_START_MS: 0,
+      TIME_TO_DOM_COMPLETE_MS: 0,
+      TIME_TO_DOM_INTERACTIVE_MS: 0,
+      TIME_TO_LOAD_EVENT_START_MS: 0,
+      TIME_TO_LOAD_EVENT_END_MS: 0,
+      TIME_TO_RESPONSE_START_MS: 0,
+      // Missing:
+      // TIME_TO_NON_BLANK_PAINT_MS ( integer)
+      // TIME_TO_DOM_LOADING_MS ( integer)
+      // TIME_TO_FIRST_INTERACTION_MS ( integer)
+      page_reloaded: false,
+      page_reloaded_survey: 0,
+      user_reported_page_breakage: false,
+      num_script_url_page: 0,
+      num_EvalError: 0,
+      num_InternalError: 0,
+      num_RangeError: 0,
+      num_ReferenceError: 0,
+      num_SyntaxError: 0,
+      num_TypeError: 0,
+      num_URIError: 0,
+      num_SecurityError: 0,
+      num_JS_exceptions: 0,
+    };
+
+    return tabInfo;
+  },
+
+  getOrInsertTabInfo(tabId) {
+    let tabInfo = this._tabs.get(tabId);
+    if (tabInfo) {
+      return tabInfo;
+    }
+
+    tabInfo = {
+      surveyShown: false,
+      reloadCount: 0,
+      hasTrackers: false,
+    };
+
+    this._tabs.set(tabId, tabInfo);
+    this.resetPayload(tabId);
+    return tabInfo;
+  },
+
+  deleteTabEntry(tabId) {
+    this._tabs.delete(tabId);
+  },
+};


### PR DESCRIPTION
Hi Erica,

this commit switches us to do per-tab tracking instead of using a global attribute. It also removes the timeout entirely and only submits on navigation.

TODO is still removing the tab and sending the telemetry when the tab closes.

It would be great if you could already have a look at this and let me know what you think. I hope I could simplify a bunch of stuff but I'm also going to add a few more comments.