### PR TITLE
[WIP] Add page breakages to the telemetry payload.

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -209,6 +209,21 @@ class Feature {
         tabInfo.telemetryPayload.page_reloaded_survey = SURVEY_PAGE_NOT_BROKEN;
       },
     );
+
+    browser.trackers.onErrorDetected.addListener(
+      (error, tabId) => {
+        this.recordPageError(error, tabId);
+      }
+    );
+  }
+
+  recordPageError(error, tabId) {
+    const tabInfo = TabRecords.getOrInsertTabInfo(tabId);
+    if (`num_${error}` in tabInfo.telemetryPayload) {
+      tabInfo.telemetryPayload[`num_${error}`] += 1;
+    } else {
+      tabInfo.telemetryPayload.num_JS_exceptions += 1;
+    }
   }
 
   generateUUID() {

--- a/src/privileged/trackers/framescript.js
+++ b/src/privileged/trackers/framescript.js
@@ -29,3 +29,8 @@ const filter = Cc["@mozilla.org/appshell/component/browser-status-filter;1"].cre
 filter.addProgressListener(trackerListener, Ci.nsIWebProgress.NOTIFY_ALL);
 const webProgress = docShell.QueryInterface(Ci.nsIInterfaceRequestor).getInterface(Ci.nsIWebProgress);
 webProgress.addProgressListener(filter, Ci.nsIWebProgress.NOTIFY_ALL);
+
+// Listen for errors from the content.
+addEventListener("error", function(e) {
+  sendAsyncMessage("pageError", e.error.name);
+});

--- a/src/privileged/trackers/schema.json
+++ b/src/privileged/trackers/schema.json
@@ -27,6 +27,15 @@
         "parameters": [
           {"type": "integer", "name": "tabId", "minimum": 0}
         ]
+      },
+      {
+        "name": "onErrorDetected",
+        "type": "function",
+        "description": "There is a page error",
+        "parameters": [
+          {"type": "string", "name": "error"},
+          {"type": "integer", "name": "tabId", "minimum": 0}
+        ]
       }
     ]
   }


### PR DESCRIPTION
**WIP**
Test on this page to trigger types of errors: https://mozilla.github.io/FastBlockShield/
note: these errors were created by me using for example: `throw EvalError("custom eval error");` 
There is also tracking on the site from GA so on refresh we can see the ping.

It may also be good to test these in the wild. One site I found is: http://consle.com/instance/examples/#handle_javascript_errors for `referenceError`.


~~todo: implement security error on the testing page so I can test it~~

note: I was not certain what `num_JS_exceptions` meant, so I decided it was all the other errors that might not be the ones listed.

fixes: #22 