### PR TITLE
Cleanup on uninstall.

### DIFF
--- a/src/privileged/notificationBar/api.js
+++ b/src/privileged/notificationBar/api.js
@@ -90,7 +90,7 @@ this.notificationBar = class extends ExtensionAPI {
    * Goes through each 'browser' for a window and removes the notification, if it exists.
    */
   onShutdown(shutdownReason) {
-    // TODO: clean the notification this from all browser windows. depends on https://github.com/mozilla/FastBlockShield/issues/50
+    // TODO: clean the notification from all browser windows. depends on https://github.com/mozilla/FastBlockShield/issues/50
     const recentWindow = getMostRecentBrowserWindow();
     const doc = recentWindow.document;
 

--- a/src/privileged/notificationBar/api.js
+++ b/src/privileged/notificationBar/api.js
@@ -87,13 +87,20 @@ class NotificationBarEventEmitter extends EventEmitter {
 this.notificationBar = class extends ExtensionAPI {
   /**
    * Extension Shutdown
-   * APIs that allocate any resources (e.g., adding elements to the browser’s user interface,
-   * setting up internal event listeners, etc.) must free these resources when the extension
-   * for which they are allocated is shut down.
+   * Goes through each 'browser' for a window and removes the notification, if it exists.
    */
   onShutdown(shutdownReason) {
-    console.log("onShutdown", shutdownReason);
-    // TODO: remove any active ui
+    // TODO: clean the notification this from all browser windows. depends on https://github.com/mozilla/FastBlockShield/issues/50
+    const recentWindow = getMostRecentBrowserWindow();
+    const doc = recentWindow.document;
+
+    recentWindow.gBrowser.browsers.forEach((browser) => {
+      let notification = doc.defaultView.PopupNotifications
+                         .getNotification("fast-block-notification", browser);
+      if (notification) {
+        doc.defaultView.PopupNotifications.remove(notification);
+      }
+    });
   }
 
   getAPI(context) {

--- a/src/privileged/prefs/api.js
+++ b/src/privileged/prefs/api.js
@@ -12,4 +12,15 @@ this.prefs = class extends ExtensionAPI {
       prefs: Services.prefs
     };
   }
+
+  // Cleanup prefs from here because the cleanup methods in the extension are not properly triggering.
+  // See for progress: https://github.com/mozilla/shield-studies-addon-utils/issues/246
+  onShutdown(shutdownReason) {
+    // Reset these to default values (we should not have recruited anyone who did not originally have default values here)
+    Services.prefs.clearUserPref("privacy.fastblock.list");
+    Services.prefs.clearUserPref("browser.fastblock.enabled");
+    Services.prefs.clearUserPref("browser.fastblock.timeout");
+    Services.prefs.clearUserPref("privacy.trackingprotection.enabled");
+    Services.prefs.clearUserPref("network.http.tailing.enabled")
+  }
 };

--- a/test/functional/0-setup.js
+++ b/test/functional/0-setup.js
@@ -46,7 +46,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -65,7 +71,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -84,7 +96,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -103,7 +121,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -123,7 +147,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -143,7 +173,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -163,7 +199,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -183,7 +225,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -203,7 +251,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -223,7 +277,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -243,7 +303,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -263,7 +329,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -279,7 +351,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });
@@ -298,7 +376,13 @@ describe("setup and teardown", function() {
 
       await utils.setupWebdriver.uninstallAddon(driver, addonId);
 
-      // TODO check that prefs were cleared
+      await checkPrefs(driver, [
+        // list pref will change see #35
+        ["privacy.fastblock.list", null],
+        ["browser.fastblock.enabled", false],
+        ["privacy.trackingprotection.enabled", false],
+        ["network.http.tailing.enabled", true],
+      ]);
 
       await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
     });


### PR DESCRIPTION
on uninstall:
- Reset changed prefs to defaults and remove added prefs. I cleared prefs from the prefs API because The backgrounds scripts' `cleanup` functions don't currently work.

- Remove the popup from each page. (Also depends on #50 to ensure this extension is running on all windows)

Issues: 
- frame scripts [cannot be unloaded](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Multiprocess_Firefox/Message_Manager/Frame_script_loading_and_lifetime#Unloading_frame_scripts) once they have been loaded, not until the tab has been closed. so those have to be left hanging around.

- I'm trying to find a way to clear `storage.local` and `storage.async` from the APIs unfortunately this is no good so far. Message passing also does not work since the extension gets uninstalled first before the API's onShutdown function is called. 


