### PR TITLE
 Include number of total and blocked trackers in Telemetry (fixes #29)

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -117,12 +117,14 @@ class Feature {
     // Whenever trackers are detected on a tab, record their presence.
     browser.trackers.listenForTrackers();
     browser.trackers.onRecordTrackers.addListener(
-      tabId => {
+      (tabId, trackersFound, trackersBlocked) => {
         if (tabId < 0) {
           return;
         }
         const tabInfo = TabRecords.getOrInsertTabInfo(tabId);
         tabInfo.hasTrackers = true;
+        tabInfo.telemetryPayload.num_blockable_trackers = trackersFound;
+        tabInfo.telemetryPayload.num_trackers_blocked = trackersBlocked;
       }
     );
 

--- a/src/privileged/trackers/api.js
+++ b/src/privileged/trackers/api.js
@@ -15,8 +15,8 @@ XPCOMUtils.defineLazyModuleGetter(
 );
 
 class TrackersEventEmitter extends EventEmitter {
-  emitTrackersExist(tabId) {
-    this.emit("trackers-exist", {tabId});
+  emitTrackersExist(tabId, trackersFound, trackersBlocked) {
+    this.emit("trackers-exist", tabId, trackersFound, trackersBlocked);
   }
   emitErrorDetected(error, tabId) {
     this.emit("page-error-detected", error, tabId);
@@ -53,10 +53,9 @@ this.trackers = class extends ExtensionAPI {
           mm.removeMessageListener("pageError", this.pageErrorCallback);
         },
         async trackerCallback(e) {
-          if (e.data.content) {
-            const tabId = tabTracker.getBrowserTabId(e.target);
-            trackersEventEmitter.emitTrackersExist(tabId);
-          }
+          const tabId = tabTracker.getBrowserTabId(e.target);
+          trackersEventEmitter.emitTrackersExist(tabId,
+            e.data.trackersFound, e.data.trackersBlocked);
         },
         async pageErrorCallback(e) {
           const tabId = tabTracker.getBrowserTabId(e.target);
@@ -77,8 +76,8 @@ this.trackers = class extends ExtensionAPI {
           context,
           "trackers.onRecordTrackers",
           fire => {
-            const listener = (value, {tabId}) => {
-              fire.async(tabId);
+            const listener = (value, tabId, trackersFound, trackersBlocked) => {
+              fire.async(tabId, trackersFound, trackersBlocked);
             };
             trackersEventEmitter.on(
               "trackers-exist",

--- a/src/privileged/trackers/framescript.js
+++ b/src/privileged/trackers/framescript.js
@@ -1,19 +1,14 @@
 /* global XPCOMUtils, sendAsyncMessage, docShell */
 const {classes: Cc, interfaces: Ci} = Components;
 const trackerListener = {
-  QueryInterface: XPCOMUtils.generateQI(["nsIWebProgressListener", "nsISupportsWeakReference"]),
+  QueryInterface: ChromeUtils.generateQI(["nsIWebProgressListener", "nsISupportsWeakReference"]),
   onSecurityChange(webProgress, request, state) {
-    const isBlocking = state & Ci.nsIWebProgressListener.STATE_BLOCKED_TRACKING_CONTENT;
-    const isAllowing = state & Ci.nsIWebProgressListener.STATE_LOADED_TRACKING_CONTENT;
-    if (isBlocking || isAllowing) {
-      // There are trackers on this page.
+    // This information should be stored on the top-level document, including
+    // tracker information for iframe documents.
+    if (docShell.document.numTrackersFound > 0) {
       sendAsyncMessage("trackerStatus", {
-        content: true,
-      });
-    } else {
-      // There are no trackers on this page
-      sendAsyncMessage("trackerStatus", {
-        content: false,
+        trackersFound: docShell.document.numTrackersFound,
+        trackersBlocked: docShell.document.numTrackersBlocked,
       });
     }
   },

--- a/src/privileged/trackers/schema.json
+++ b/src/privileged/trackers/schema.json
@@ -17,7 +17,9 @@
         "type": "function",
         "description": "There is at least one tracker on this site.",
         "parameters": [
-          {"type": "integer", "name": "tabId", "minimum": 0}
+          {"type": "integer", "name": "tabId", "minimum": 0},
+          {"type": "integer", "name": "trackersFound", "minimum": 0},
+          {"type": "integer", "name": "trackersBlocked", "minimum": 0}
         ]
       },
       {

--- a/test/functional/1-telemetry.js
+++ b/test/functional/1-telemetry.js
@@ -20,6 +20,7 @@ describe("telemetry", function() {
     driver = await utils.setupWebdriver.promiseSetupDriver(
       utils.FIREFOX_PREFERENCES,
     );
+    await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "TPL0");
     await utils.setupWebdriver.installAddon(driver);
   });
 
@@ -44,6 +45,13 @@ describe("telemetry", function() {
       const attributes = ping.payload.data.attributes;
       assert.equal(attributes.page_reloaded, "false", "page reloaded is false");
       assert.equal(parseInt(attributes.page_reloaded_survey), 0, "page reloaded survey not shown");
+    });
+
+    it("correctly records the amount of trackers on the page", async () => {
+      let ping = studyPings[0];
+      let attributes = ping.payload.data.attributes;
+      assert.equal(attributes.num_blockable_trackers, "1", "found a blockable tracker");
+      assert.equal(attributes.num_trackers_blocked, "1", "found blocked trackers");
     });
 
     it("correctly records performance metrics", async () => {

--- a/test/functional/2-trackers.js
+++ b/test/functional/2-trackers.js
@@ -1,0 +1,199 @@
+/* eslint-env node, mocha */
+
+// for unhandled promise rejection debugging
+process.on("unhandledRejection", r => console.error(r)); // eslint-disable-line no-console
+
+const {assert} = require("chai");
+const utils = require("./utils");
+const firefox = require("selenium-webdriver/firefox");
+const Context = firefox.Context;
+
+describe("trackers", function() {
+  // This gives Firefox time to start, and us a bit longer during some of the tests.
+  this.timeout(15000);
+
+  let driver;
+
+  // runs ONCE
+  before(async () => {
+    driver = await utils.setupWebdriver.promiseSetupDriver(
+      utils.FIREFOX_PREFERENCES,
+    );
+    await utils.setupWebdriver.installAddon(driver);
+  });
+
+  after(() => {
+    driver.quit();
+  });
+
+  describe("recording trackers with FB and TP turned off", function() {
+    it.skip("This depends on platform support");
+    return;
+
+    let studyPings;
+
+    before(async () => {
+      await utils.setPreference(driver, "browser.fastblock.enabled", false);
+      await utils.setPreference(driver, "privacy.trackingprotection.enabled", false);
+      await driver.sleep(1000);
+
+      let time = Date.now();
+      driver.setContext(Context.CONTENT);
+      await driver.get("https://example.com");
+      await driver.sleep(1000);
+      await driver.get("https://mozilla.github.io/tracking-test/disconnect.html");
+      await driver.sleep(1000);
+      await driver.get("https://example.com");
+      await driver.sleep(500);
+      studyPings = await utils.telemetry.getShieldPingsAfterTimestamp(
+        driver,
+        time,
+      );
+      studyPings = studyPings.filter(ping => ping.type === "shield-study-addon");
+    });
+
+    it("has recorded one ping", async () => {
+      assert(studyPings.length == 1, "one shield telemetry ping");
+    });
+
+    it("correctly records the amount of trackers on the page", async () => {
+      let ping = studyPings[0];
+      let attributes = ping.payload.data.attributes;
+      assert.equal(attributes.num_blockable_trackers, "3", "found all blockable trackers");
+      assert.equal(attributes.num_trackers_blocked, "0", "found no blocked trackers");
+    });
+
+    after(async () => {
+      await utils.clearPreference(driver, "browser.fastblock.enabled");
+      await utils.clearPreference(driver, "privacy.trackingprotection.enabled");
+    });
+  });
+
+
+  describe("recording trackers with FB not blocking", function() {
+    it.skip("This depends on platform support");
+    return;
+
+    let studyPings;
+
+    before(async () => {
+      await utils.setPreference(driver, "browser.fastblock.enabled", true);
+      await utils.setPreference(driver, "browser.fastblock.timeout", 10000);
+      await utils.setPreference(driver, "privacy.trackingprotection.enabled", false);
+
+      let time = Date.now();
+      driver.setContext(Context.CONTENT);
+      await driver.get("https://example.com");
+      await driver.sleep(1000);
+      await driver.get("https://mozilla.github.io/tracking-test/disconnect.html");
+      await driver.sleep(5000);
+      await driver.get("https://example.com");
+      await driver.sleep(1000);
+      studyPings = await utils.telemetry.getShieldPingsAfterTimestamp(
+        driver,
+        time,
+      );
+      studyPings = studyPings.filter(ping => ping.type === "shield-study-addon");
+    });
+
+    it("has recorded one ping", async () => {
+      assert(studyPings.length == 1, "one shield telemetry ping");
+    });
+
+    it("correctly records the amount of trackers on the page", async () => {
+      let ping = studyPings[0];
+      let attributes = ping.payload.data.attributes;
+      assert.equal(attributes.num_blockable_trackers, "3", "found all blockable trackers");
+      assert.equal(attributes.num_trackers_blocked, "0", "found no blocked trackers");
+    });
+
+    after(async () => {
+      await utils.clearPreference(driver, "browser.fastblock.enabled");
+      await utils.clearPreference(driver, "browser.fastblock.timeout");
+      await utils.clearPreference(driver, "privacy.trackingprotection.enabled");
+    });
+  });
+
+  describe("recording trackers with FB blocking", function() {
+    it.skip("This depends on platform support");
+    return;
+
+    let studyPings;
+
+    before(async () => {
+      await utils.setPreference(driver, "browser.fastblock.enabled", true);
+      await utils.setPreference(driver, "browser.fastblock.timeout", 0);
+      await utils.setPreference(driver, "privacy.trackingprotection.enabled", false);
+      await driver.sleep(1000);
+
+      let time = Date.now();
+      driver.setContext(Context.CONTENT);
+      await driver.get("https://mozilla.github.io/tracking-test/disconnect.html");
+      await driver.sleep(1000);
+      await driver.get("https://example.com");
+      await driver.sleep(1000);
+      studyPings = await utils.telemetry.getShieldPingsAfterTimestamp(
+        driver,
+        time,
+      );
+      studyPings = studyPings.filter(ping => ping.type === "shield-study-addon");
+    });
+
+    it("has recorded one ping", async () => {
+      assert(studyPings.length == 1, "one shield telemetry ping");
+    });
+
+    it("correctly records the amount of trackers on the page", async () => {
+      let ping = studyPings[0];
+      let attributes = ping.payload.data.attributes;
+      assert.equal(attributes.num_blockable_trackers, "3", "found all blockable trackers");
+      assert.equal(attributes.num_trackers_blocked, "3", "found all blocked trackers");
+    });
+
+    after(async () => {
+      await utils.clearPreference(driver, "browser.fastblock.enabled");
+      await utils.clearPreference(driver, "browser.fastblock.timeout");
+      await utils.clearPreference(driver, "privacy.trackingprotection.enabled");
+    });
+  });
+
+  describe("recording trackers with TP blocking", function() {
+    let studyPings;
+
+    before(async () => {
+      await driver.sleep(1000);
+      await utils.setPreference(driver, "browser.fastblock.enabled", false);
+      await utils.setPreference(driver, "privacy.trackingprotection.enabled", true);
+      await driver.sleep(1000);
+
+      let time = Date.now();
+      driver.setContext(Context.CONTENT);
+      await driver.get("https://itisatrap.org/firefox/its-a-tracker.html");
+      await driver.sleep(1000);
+      await driver.get("https://example.com");
+      await driver.sleep(500);
+      studyPings = await utils.telemetry.getShieldPingsAfterTimestamp(
+        driver,
+        time,
+      );
+      studyPings = studyPings.filter(ping => ping.type === "shield-study-addon");
+    });
+
+    it("has recorded one ping", async () => {
+      assert(studyPings.length == 1, "one shield telemetry ping");
+    });
+
+    it("correctly records the amount of trackers on the page", async () => {
+      let ping = studyPings[0];
+      let attributes = ping.payload.data.attributes;
+      assert.equal(attributes.num_blockable_trackers, "1", "found all blockable trackers");
+      assert.equal(attributes.num_trackers_blocked, "1", "found all blocked trackers");
+    });
+
+    after(async () => {
+      await utils.clearPreference(driver, "browser.fastblock.enabled");
+      await utils.clearPreference(driver, "privacy.trackingprotection.enabled");
+    });
+  });
+
+});


### PR DESCRIPTION
 This takes the numbers from the document, although there are a few
 flaws in the implementation on Necko side, which I will raise with
 them. See tests that are currently skipped.

 Basically this feature only works well if Tracking Protection is turned
 on.