### PR TITLE
Fix erratic timing errors in test

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
   "applications": {
     "gecko": {
       "id": "fastblock-shield@mozilla.org",
-      "strict_min_version": "62"
+      "strict_min_version": "62.0"
     }
   },
   "default_locale": "en-US",

--- a/src/privileged/notificationBar/api.js
+++ b/src/privileged/notificationBar/api.js
@@ -8,7 +8,10 @@ ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
 ChromeUtils.import("resource://gre/modules/ExtensionUtils.jsm");
 
-const {Management: {global: {tabTracker}}} = ChromeUtils.import("resource://gre/modules/Extension.jsm", {});
+/* eslint-disable-next-line */
+var {EventManager, EventEmitter} = ExtensionCommon;
+/* eslint-disable-next-line no-var */
+var {Management: {global: {tabTracker}}} = ChromeUtils.import("resource://gre/modules/Extension.jsm", {});
 
 // eslint-disable-next-line no-undef
 XPCOMUtils.defineLazyModuleGetter(
@@ -44,7 +47,6 @@ function getMostRecentBrowserWindow() {
  *      https://github.com/gregglind/57-perception-shield-study/blob/680124a/addon/lib/Feature.jsm#L148-L152
  *
  */
-// eslint-disable-next-line no-undef
 class NotificationBarEventEmitter extends EventEmitter {
   emitShow(variationName) {
     const self = this;
@@ -107,7 +109,6 @@ this.notificationBar = class extends ExtensionAPI {
         show() {
           notificationBarEventEmitter.emitShow();
         },
-        // eslint-disable-next-line no-undef
         onReportPageBroken: new EventManager(
           context,
           "notificationBar.onReportPageBroken",
@@ -127,7 +128,6 @@ this.notificationBar = class extends ExtensionAPI {
             };
           },
         ).api(),
-        // eslint-disable-next-line no-undef
         onReportPageNotBroken: new EventManager(
           context,
           "notificationBar.onReportPageNotBroken",

--- a/src/privileged/trackers/api.js
+++ b/src/privileged/trackers/api.js
@@ -4,9 +4,10 @@
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 
-const { EventManager, EventEmitter } = ExtensionCommon;
-
-const {Management: {global: {tabTracker}}} = ChromeUtils.import("resource://gre/modules/Extension.jsm", {});
+/* eslint-disable-next-line no-var */
+var {EventManager, EventEmitter} = ExtensionCommon;
+/* eslint-disable-next-line no-var */
+var {Management: {global: {tabTracker}}} = ChromeUtils.import("resource://gre/modules/Extension.jsm", {});
 
 XPCOMUtils.defineLazyModuleGetter(
   this,

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -11,12 +11,12 @@ window.TabRecords = {
       etld: null,
       num_blockable_trackers: 0,
       num_trackers_blocked: 0,
-      TIME_TO_DOM_CONTENT_LOADED_START_MS: 0,
-      TIME_TO_DOM_COMPLETE_MS: 0,
-      TIME_TO_DOM_INTERACTIVE_MS: 0,
-      TIME_TO_LOAD_EVENT_START_MS: 0,
-      TIME_TO_LOAD_EVENT_END_MS: 0,
-      TIME_TO_RESPONSE_START_MS: 0,
+      TIME_TO_DOM_CONTENT_LOADED_START_MS: -1,
+      TIME_TO_DOM_COMPLETE_MS: -1,
+      TIME_TO_DOM_INTERACTIVE_MS: -1,
+      TIME_TO_LOAD_EVENT_START_MS: -1,
+      TIME_TO_LOAD_EVENT_END_MS: -1,
+      TIME_TO_RESPONSE_START_MS: -1,
       // Missing:
       // TIME_TO_NON_BLANK_PAINT_MS ( integer)
       // TIME_TO_DOM_LOADING_MS ( integer)

--- a/test/functional/1-telemetry.js
+++ b/test/functional/1-telemetry.js
@@ -57,12 +57,12 @@ describe("telemetry", function() {
     it("correctly records performance metrics", async () => {
       const ping = studyPings[0];
       const attributes = ping.payload.data.attributes;
-      assert.isAbove(parseInt(attributes.TIME_TO_DOM_COMPLETE_MS), 0, "has TIME_TO_DOM_COMPLETE_MS data");
-      assert.isAbove(parseInt(attributes.TIME_TO_DOM_CONTENT_LOADED_START_MS), 0, "has TIME_TO_DOM_CONTENT_LOADED_START_MS data");
-      assert.isAbove(parseInt(attributes.TIME_TO_DOM_INTERACTIVE_MS), 0, "has TIME_TO_DOM_INTERACTIVE_MS data");
-      assert.isAbove(parseInt(attributes.TIME_TO_LOAD_EVENT_START_MS), 0, "has TIME_TO_LOAD_EVENT_START_MS data");
-      assert.isAbove(parseInt(attributes.TIME_TO_LOAD_EVENT_END_MS), 0, "has TIME_TO_LOAD_EVENT_END_MS data");
-      assert.isAbove(parseInt(attributes.TIME_TO_RESPONSE_START_MS), 0, "has TIME_TO_RESPONSE_START_MS data");
+      assert.isAtLeast(parseInt(attributes.TIME_TO_DOM_COMPLETE_MS), 0, "has TIME_TO_DOM_COMPLETE_MS data");
+      assert.isAtLeast(parseInt(attributes.TIME_TO_DOM_CONTENT_LOADED_START_MS), 0, "has TIME_TO_DOM_CONTENT_LOADED_START_MS data");
+      assert.isAtLeast(parseInt(attributes.TIME_TO_DOM_INTERACTIVE_MS), 0, "has TIME_TO_DOM_INTERACTIVE_MS data");
+      assert.isAtLeast(parseInt(attributes.TIME_TO_LOAD_EVENT_START_MS), 0, "has TIME_TO_LOAD_EVENT_START_MS data");
+      assert.isAtLeast(parseInt(attributes.TIME_TO_LOAD_EVENT_END_MS), 0, "has TIME_TO_LOAD_EVENT_END_MS data");
+      assert.isAtLeast(parseInt(attributes.TIME_TO_RESPONSE_START_MS), 0, "has TIME_TO_RESPONSE_START_MS data");
     });
 
     it("correctly records JS errors", async () => {


### PR DESCRIPTION
Roughly one in three times I'd run the tests the `TIME_TO_RESPONSE_START_MS` would fail. the number was generally a very small one 0-3 MS. When the number was 0, this test would fail. Now, the assertion ensures they are all at least 0, not greater than.

I understand we are defaulting these numbers to 0. Should we perhaps default them to -1?

Fixes: #70 