### PR TITLE
All the prefs!

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ In all variations:
 
 ```
 npm start -- -f Nightly --pref=extensions.button-icon-preference_shield_mozilla_org.
-test.variationName=TPL0
+test.variationName=TP
 ```
 
 In a Tracking Protection [variation](#variations):

--- a/src/feature.js
+++ b/src/feature.js
@@ -1,4 +1,4 @@
-/* global TabRecords */
+/* global TabRecords, VARIATIONS */
 
 // Constants for the page_reloaded_survey telemetry probe.
 const SURVEY_SHOWN = 1;
@@ -9,7 +9,7 @@ class Feature {
   constructor() {}
 
   async configure(studyInfo) {
-    const { variation } = studyInfo;
+    let { variation } = studyInfo;
 
     // The userid will be used to create a unique hash
     // for the etld + userid combination.
@@ -20,98 +20,19 @@ class Feature {
     }
     this.userid = userid;
 
-    // TODO: how will I get the lists, will it be a pref?
-    // TODO reduce this to an array of sorts
-    switch (variation.name) {
-      case "TPL0":
-        browser.prefs.setIntPref("privacy.fastblock.list", 0);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", false);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", true);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", false);
-        break;
-      case "TPL1":
-        browser.prefs.setIntPref("privacy.fastblock.list", 1);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", false);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", true);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", false);
-        break;
-      case "TPL2":
-        browser.prefs.setIntPref("privacy.fastblock.list", 2);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", false);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", true);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", false);
-        break;
-      case "TPL3":
-        browser.prefs.setIntPref("privacy.fastblock.list", 3);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", false);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", true);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", false);
-        break;
-      case "FB2L0":
-        browser.prefs.setIntPref("privacy.fastblock.list", 0);
-        browser.prefs.setIntPref("browser.fastblock.timeout", 2000);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", true);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", false);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", false);
-        break;
-      case "FB2L1":
-        browser.prefs.setIntPref("privacy.fastblock.list", 1);
-        browser.prefs.setIntPref("browser.fastblock.timeout", 2000);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", true);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", false);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", false);
-        break;
-      case "FB2L2":
-        browser.prefs.setIntPref("privacy.fastblock.list", 2);
-        browser.prefs.setIntPref("browser.fastblock.timeout", 2000);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", true);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", false);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", false);
-        break;
-      case "FB2L3":
-        browser.prefs.setIntPref("privacy.fastblock.list", 3);
-        browser.prefs.setIntPref("browser.fastblock.timeout", 2000);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", true);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", false);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", false);
-        break;
-      case "FB5L0":
-        browser.prefs.setIntPref("privacy.fastblock.list", 0);
-        browser.prefs.setIntPref("browser.fastblock.timeout", 5000);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", true);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", false);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", false);
-        break;
-      case "FB5L1":
-        browser.prefs.setIntPref("privacy.fastblock.list", 1);
-        browser.prefs.setIntPref("browser.fastblock.timeout", 5000);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", true);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", false);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", false);
-        break;
-      case "FB5L2":
-        browser.prefs.setIntPref("privacy.fastblock.list", 2);
-        browser.prefs.setIntPref("browser.fastblock.timeout", 5000);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", true);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", false);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", false);
-        break;
-      case "FB5L3":
-        browser.prefs.setIntPref("privacy.fastblock.list", 3);
-        browser.prefs.setIntPref("browser.fastblock.timeout", 5000);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", true);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", false);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", false);
-        break;
-      case "Control":
-        browser.prefs.setBoolPref("browser.fastblock.enabled", false);
-        break;
-      case "TT":
-        browser.prefs.setIntPref("privacy.fastblock.list", 0);
-        browser.prefs.setBoolPref("browser.fastblock.enabled", true);
-        browser.prefs.setBoolPref("privacy.trackingprotection.enabled", false);
-        browser.prefs.setBoolPref("network.http.tailing.enabled", true);
-        break;
+    variation = VARIATIONS[variation.name];
+
+    for (const pref in variation.prefs) {
+      browser.prefs.registerPrefCleanup(pref);
+
+      const value = variation.prefs[pref];
+      if (typeof value === "boolean") {
+        browser.prefs.setBoolPref(pref, value);
+      } else if (typeof value === "string") {
+        browser.prefs.setStringPref(pref, value);
+      } else if (typeof value === "number") {
+        browser.prefs.setIntPref(pref, value);
+      }
     }
 
     // Whenever trackers are detected on a tab, record their presence.
@@ -268,7 +189,8 @@ class Feature {
    * Called at end of study, and if the user disables the study or it gets uninstalled by other means.
    */
   async cleanup() {
-    // TODO: put prefs back
+    // This is not triggering properly, see
+    // https://github.com/mozilla/shield-studies-addon-utils/issues/246
   }
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -57,7 +57,7 @@
   ],
   "permissions": ["management", "storage", "alarms", "webNavigation"],
   "background": {
-    "scripts": ["studySetup.js", "feature.js", "background.js", "tabs.js"]
+    "scripts": ["variations.js", "studySetup.js", "feature.js", "background.js", "tabs.js"]
   },
   "content_scripts": [
     {

--- a/src/privileged/prefs/api.js
+++ b/src/privileged/prefs/api.js
@@ -4,23 +4,31 @@
 
 ChromeUtils.import("resource://gre/modules/Services.jsm");
 
+const cleanupPrefs = new Set();
+
 /* https://firefox-source-docs.mozilla.org/toolkit/components/extensions/webextensions/functions.html */
 this.prefs = class extends ExtensionAPI {
   getAPI(context) {
     return {
-      // eslint-disable-next-line no-undef
-      prefs: Services.prefs
+      prefs: {
+        registerPrefCleanup(pref) {
+          cleanupPrefs.add(pref);
+        },
+        setStringPref: Services.prefs.setStringPref,
+        getStringPref: Services.prefs.getStringPref,
+        setIntPref: Services.prefs.setIntPref,
+        getIntPref: Services.prefs.getIntPref,
+        setBoolPref: Services.prefs.setBoolPref,
+        getBoolPref: Services.prefs.getBoolPref,
+      }
     };
   }
 
   // Cleanup prefs from here because the cleanup methods in the extension are not properly triggering.
   // See for progress: https://github.com/mozilla/shield-studies-addon-utils/issues/246
   onShutdown(shutdownReason) {
-    // Reset these to default values (we should not have recruited anyone who did not originally have default values here)
-    Services.prefs.clearUserPref("privacy.fastblock.list");
-    Services.prefs.clearUserPref("browser.fastblock.enabled");
-    Services.prefs.clearUserPref("browser.fastblock.timeout");
-    Services.prefs.clearUserPref("privacy.trackingprotection.enabled");
-    Services.prefs.clearUserPref("network.http.tailing.enabled")
+    for (let pref of cleanupPrefs) {
+      Services.prefs.clearUserPref(pref);
+    }
   }
 };

--- a/src/privileged/prefs/schema.json
+++ b/src/privileged/prefs/schema.json
@@ -4,6 +4,46 @@
     "description": "Pref get, set, watch, unwatch(?)",
     "functions": [
       {
+        "name": "registerPrefCleanup",
+        "type": "function",
+        "description": "Registers a pref name to be cleaned up on uninstall",
+        "async": true,
+        "parameters": [
+          {
+            "name": "prefName",
+            "type": "string"
+          }
+        ]
+      },
+      {
+        "name": "setStringPref",
+        "type": "function",
+        "description": "Sets the value of a string pref",
+        "async": true,
+        "parameters": [
+          {
+            "name": "prefName",
+            "type": "string"
+          },
+          {
+            "name": "value",
+            "type": "string"
+          }
+        ]
+      },
+      {
+        "name": "getStringPref",
+        "type": "function",
+        "description": "Returns the value of a string pref",
+        "async": true,
+        "parameters": [
+          {
+            "name": "prefName",
+            "type": "string"
+          }
+        ]
+      },
+      {
         "name": "setIntPref",
         "type": "function",
         "description": "Sets the value of an int pref",

--- a/src/studySetup.js
+++ b/src/studySetup.js
@@ -1,4 +1,5 @@
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "getStudySetup" }]*/
+/* global VARIATIONS */
 
 /**
  *  Overview:
@@ -13,15 +14,6 @@
  *  - some user defined endings.
  *  - study defined 'shouldAllowEnroll' logic.
  */
-
-
-const variations = [
-  "TPL0", "TPL1", "TPL2", "TPL3",
-  "FB2L0", "FB2L1", "FB2L2", "FB2L3",
-  "FB5L0", "FB5L1", "FB5L2", "FB5L3",
-  "Control", "TT",
-];
-
 
 /** Base for studySetup, as used by `browser.study.setup`.
  *
@@ -78,9 +70,8 @@ const baseStudySetup = {
     },
   },
 
-  weightedVariations: variations.map(variation => { return {name: variation, weight: 1}; }),
+  weightedVariations: null,
 
-  // TODO: does this exclude the recruitment period?
   // maximum time that the study should run, from the first run
   expire: {
     days: 21,
@@ -128,6 +119,10 @@ async function cachingFirstRunShouldAllowEnroll() {
 async function getStudySetup() {
   // shallow copy
   const studySetup = Object.assign({}, baseStudySetup);
+
+  studySetup.weightedVariations = Object.keys(VARIATIONS).map(variation => {
+    return {name: variation, weight: VARIATIONS[variation].weight};
+  });
 
   studySetup.allowEnroll = await cachingFirstRunShouldAllowEnroll();
 

--- a/src/variations.js
+++ b/src/variations.js
@@ -1,0 +1,344 @@
+window.VARIATIONS = {
+  "TP": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": false,
+      "privacy.trackingprotection.enabled": true,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      // Reset TP list to the default value.
+      "urlclassifier.trackingTable": "test-track-simple,base-track-digest256",
+
+      // Disable FastBlock UI.
+      "browser.contentblocking.fastblock.ui.enabled": false,
+      "browser.contentblocking.fastblock.control-center.ui.enabled": false,
+    },
+  },
+
+  "FB2L0": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": true,
+      "browser.fastblock.timeout": 2000,
+      "privacy.trackingprotection.enabled": false,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      // L0 gets the default lists.
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
+      "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256",
+
+      // Disable TP UI.
+      "browser.contentblocking.trackingprotection.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+    },
+  },
+
+  "FB2L1": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": true,
+      "browser.fastblock.timeout": 2000,
+      "privacy.trackingprotection.enabled": false,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock1-track-digest256",
+      "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256,fastblock1-trackwhite-digest256",
+
+      // Disable TP UI.
+      "browser.contentblocking.trackingprotection.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+    },
+  },
+
+  "FB2L2": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": true,
+      "browser.fastblock.timeout": 2000,
+      "privacy.trackingprotection.enabled": false,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock2-track-digest256",
+      "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256,fastblock2-trackwhite-digest256",
+
+      // Disable TP UI.
+      "browser.contentblocking.trackingprotection.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+    },
+  },
+
+  "FB2L3": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": true,
+      "browser.fastblock.timeout": 2000,
+      "privacy.trackingprotection.enabled": false,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock3-track-digest256",
+      "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256",
+
+      // Disable TP UI.
+      "browser.contentblocking.trackingprotection.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+    },
+  },
+
+  "FB5L0": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": true,
+      "browser.fastblock.timeout": 5000,
+      "privacy.trackingprotection.enabled": false,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      // L0 gets the default lists.
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
+      "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256",
+
+      // Disable TP UI.
+      "browser.contentblocking.trackingprotection.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+    },
+  },
+
+  "FB5L1": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": true,
+      "browser.fastblock.timeout": 5000,
+      "privacy.trackingprotection.enabled": false,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock1-track-digest256",
+      "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256,fastblock1-trackwhite-digest256",
+
+      // Disable TP UI.
+      "browser.contentblocking.trackingprotection.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+    },
+  },
+
+  "FB5L2": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": true,
+      "browser.fastblock.timeout": 5000,
+      "privacy.trackingprotection.enabled": false,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock2-track-digest256",
+      "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256,fastblock2-trackwhite-digest256",
+
+      // Disable TP UI.
+      "browser.contentblocking.trackingprotection.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+    },
+  },
+
+  "FB5L3": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": true,
+      "browser.fastblock.timeout": 5000,
+      "privacy.trackingprotection.enabled": false,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock3-track-digest256",
+      "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256",
+
+      // Disable TP UI.
+      "browser.contentblocking.trackingprotection.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+    },
+  },
+
+  "ControlL0": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": false,
+      "privacy.trackingprotection.enabled": false,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
+      "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256",
+
+      // Disable TP and FastBlock UI.
+      "browser.contentblocking.fastblock.ui.enabled": false,
+      "browser.contentblocking.fastblock.control-center.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+    },
+  },
+
+  "ControlL1": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": false,
+      "privacy.trackingprotection.enabled": false,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock1-track-digest256",
+      "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256,fastblock1-trackwhite-digest256",
+
+      // Disable TP and FastBlock UI.
+      "browser.contentblocking.fastblock.ui.enabled": false,
+      "browser.contentblocking.fastblock.control-center.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+    },
+  },
+
+  "ControlL2": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": false,
+      "privacy.trackingprotection.enabled": false,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock2-track-digest256",
+      "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256,fastblock2-trackwhite-digest256",
+
+      // Disable TP and FastBlock UI.
+      "browser.contentblocking.fastblock.ui.enabled": false,
+      "browser.contentblocking.fastblock.control-center.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+    },
+  },
+
+  "ControlL3": {
+    weight: 1,
+    prefs: {
+      // Always turn on Content Blocking.
+      "browser.contentblocking.enabled": true,
+      "browser.contentblocking.ui.enabled": true,
+
+      // Make sure we're not affected by the Symantec distrust.
+      "security.pki.distrust_ca_policy": 1,
+
+      "browser.fastblock.enabled": false,
+      "privacy.trackingprotection.enabled": false,
+
+      // Make sure to enable tailing.
+      "network.http.tailing.enabled": true,
+
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock3-track-digest256",
+      "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256",
+
+      // Disable TP and FastBlock UI.
+      "browser.contentblocking.fastblock.ui.enabled": false,
+      "browser.contentblocking.fastblock.control-center.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.ui.enabled": false,
+      "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+    },
+  },
+};

--- a/test/functional/0-setup.js
+++ b/test/functional/0-setup.js
@@ -6,10 +6,32 @@ process.on("unhandledRejection", r => console.error(r)); // eslint-disable-line 
 const {assert} = require("chai");
 const utils = require("./utils");
 
+const allPrefs = [
+  "browser.contentblocking.enabled",
+  "browser.contentblocking.ui.enabled",
+  "security.pki.distrust_ca_policy",
+  "browser.fastblock.enabled",
+  "browser.fastblock.timeout",
+  "privacy.trackingprotection.enabled",
+  "network.http.tailing.enabled",
+  "urlclassifier.trackingTable",
+  "urlclassifier.trackingAnnotationTable",
+  "urlclassifier.trackingAnnotationWhitelistTable",
+  "browser.contentblocking.fastblock.ui.enabled",
+  "browser.contentblocking.fastblock.control-center.ui.enabled",
+  "browser.contentblocking.trackingprotection.ui.enabled",
+  "browser.contentblocking.trackingprotection.control-center.ui.enabled",
+];
+
 async function checkPrefs(driver, prefs) {
-  for (const [name, value] of prefs) {
-    const val = await utils.getPreference(driver, name);
-    assert.equal(val, value, `set the right pref for ${name}`);
+  for (const pref of allPrefs) {
+    if (prefs[pref] != undefined) {
+      const val = await utils.getPreference(driver, pref);
+      assert.equal(val, prefs[pref], `set the right pref for ${pref}`);
+    } else {
+      const hasUserValue = await utils.prefHasUserValue(driver, pref);
+      assert.isFalse(hasUserValue, `${pref} is set to the default`);
+    }
   }
 }
 
@@ -32,360 +54,437 @@ describe("setup and teardown", function() {
 
   describe("sets up the correct prefs, depending on the variation", function() {
     const SETUP_DELAY = 500;
+    let addonId;
 
-    it("sets the correct prefs for variation TPL0", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "TPL0");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation TP", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "TP");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 0],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", true],
-        ["network.http.tailing.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": false,
+          "privacy.trackingprotection.enabled": true,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingTable": "test-track-simple,base-track-digest256",
+          "browser.contentblocking.fastblock.ui.enabled": false,
+          "browser.contentblocking.fastblock.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
-    it("sets the correct prefs for variation TPL1", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "TPL1");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation FB2L0", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB2L0");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 1],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", true],
-        ["network.http.tailing.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": true,
+          "browser.fastblock.timeout": 2000,
+          "privacy.trackingprotection.enabled": false,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
+          "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256",
+          "browser.contentblocking.trackingprotection.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
-    it("sets the correct prefs for variation TPL2", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "TPL2");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation FB2L1", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB2L1");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 2],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", true],
-        ["network.http.tailing.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": true,
+          "browser.fastblock.timeout": 2000,
+          "privacy.trackingprotection.enabled": false,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock1-track-digest256",
+          "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256,fastblock1-trackwhite-digest256",
+          "browser.contentblocking.trackingprotection.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
-    it("sets the correct prefs for variation TPL3", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "TPL3");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation FB2L2", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB2L2");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 3],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", true],
-        ["network.http.tailing.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": true,
+          "browser.fastblock.timeout": 2000,
+          "privacy.trackingprotection.enabled": false,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock2-track-digest256",
+          "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256,fastblock2-trackwhite-digest256",
+          "browser.contentblocking.trackingprotection.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
-    it("sets the correct prefs for variation FB2L0", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB2L0");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation FB2L3", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB2L3");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 0],
-        ["browser.fastblock.timeout", 2000],
-        ["browser.fastblock.enabled", true],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": true,
+          "browser.fastblock.timeout": 2000,
+          "privacy.trackingprotection.enabled": false,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock3-track-digest256",
+          "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256",
+          "browser.contentblocking.trackingprotection.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
-    it("sets the correct prefs for variation FB2L1", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB2L1");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation FB5L0", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB5L0");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 1],
-        ["browser.fastblock.timeout", 2000],
-        ["browser.fastblock.enabled", true],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": true,
+          "browser.fastblock.timeout": 5000,
+          "privacy.trackingprotection.enabled": false,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
+          "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256",
+          "browser.contentblocking.trackingprotection.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
-    it("sets the correct prefs for variation FB2L2", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB2L2");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation FB5L1", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB5L1");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 2],
-        ["browser.fastblock.timeout", 2000],
-        ["browser.fastblock.enabled", true],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": true,
+          "browser.fastblock.timeout": 5000,
+          "privacy.trackingprotection.enabled": false,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock1-track-digest256",
+          "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256,fastblock1-trackwhite-digest256",
+          "browser.contentblocking.trackingprotection.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
-    it("sets the correct prefs for variation FB2L3", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB2L3");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation FB5L2", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB5L2");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 3],
-        ["browser.fastblock.timeout", 2000],
-        ["browser.fastblock.enabled", true],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": true,
+          "browser.fastblock.timeout": 5000,
+          "privacy.trackingprotection.enabled": false,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock2-track-digest256",
+          "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256,fastblock2-trackwhite-digest256",
+          "browser.contentblocking.trackingprotection.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
-    it("sets the correct prefs for variation FB5L0", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB5L0");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation FB5L3", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB5L3");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 0],
-        ["browser.fastblock.timeout", 5000],
-        ["browser.fastblock.enabled", true],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": true,
+          "browser.fastblock.timeout": 5000,
+          "privacy.trackingprotection.enabled": false,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock3-track-digest256",
+          "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256",
+          "browser.contentblocking.trackingprotection.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
-    it("sets the correct prefs for variation FB5L1", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB5L1");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation ControlL0", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "ControlL0");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 1],
-        ["browser.fastblock.timeout", 5000],
-        ["browser.fastblock.enabled", true],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": false,
+          "privacy.trackingprotection.enabled": false,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
+          "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256",
+          "browser.contentblocking.fastblock.ui.enabled": false,
+          "browser.contentblocking.fastblock.control-center.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
-    it("sets the correct prefs for variation FB5L2", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB5L2");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation ControlL1", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "ControlL1");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 2],
-        ["browser.fastblock.timeout", 5000],
-        ["browser.fastblock.enabled", true],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": false,
+          "privacy.trackingprotection.enabled": false,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock1-track-digest256",
+          "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256,fastblock1-trackwhite-digest256",
+          "browser.contentblocking.fastblock.ui.enabled": false,
+          "browser.contentblocking.fastblock.control-center.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
-    it("sets the correct prefs for variation FB5L3", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "FB5L3");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation ControlL2", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "ControlL2");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 3],
-        ["browser.fastblock.timeout", 5000],
-        ["browser.fastblock.enabled", true],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": false,
+          "privacy.trackingprotection.enabled": false,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock2-track-digest256",
+          "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256,fastblock2-trackwhite-digest256",
+          "browser.contentblocking.fastblock.ui.enabled": false,
+          "browser.contentblocking.fastblock.control-center.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
-    it("sets the correct prefs for variation Control", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "Control");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
+    describe("sets the correct prefs for variation ControlL3", () => {
+      before(async () => {
+        await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "ControlL3");
+        addonId = await utils.setupWebdriver.installAddon(driver);
+        await driver.sleep(SETUP_DELAY);
+      });
 
-      await checkPrefs(driver, [
-        ["browser.fastblock.enabled", false],
-      ]);
+      it("has the correct prefs after install", async () => {
+        await checkPrefs(driver, {
+          "browser.contentblocking.enabled": true,
+          "browser.contentblocking.ui.enabled": true,
+          "security.pki.distrust_ca_policy": 1,
+          "browser.fastblock.enabled": false,
+          "privacy.trackingprotection.enabled": false,
+          "network.http.tailing.enabled": true,
+          "urlclassifier.trackingAnnotationTable": "test-track-simple,fastblock3-track-digest256",
+          "urlclassifier.trackingAnnotationWhitelistTable": "test-trackwhite-simple,mozstd-trackwhite-digest256",
+          "browser.contentblocking.fastblock.ui.enabled": false,
+          "browser.contentblocking.fastblock.control-center.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.ui.enabled": false,
+          "browser.contentblocking.trackingprotection.control-center.ui.enabled": false,
+        });
+      });
 
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
+      it("has the correct prefs after uninstall", async () => {
+        await utils.setupWebdriver.uninstallAddon(driver, addonId);
+        await checkPrefs(driver, {});
+      });
 
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
-    });
-
-    it("sets the correct prefs for variation TT", async () => {
-      await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "TT");
-      const addonId = await utils.setupWebdriver.installAddon(driver);
-      await driver.sleep(SETUP_DELAY);
-
-      await checkPrefs(driver, [
-        ["privacy.fastblock.list", 0],
-        ["browser.fastblock.enabled", true],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.setupWebdriver.uninstallAddon(driver, addonId);
-
-      await checkPrefs(driver, [
-        // list pref will change see #35
-        ["privacy.fastblock.list", null],
-        ["browser.fastblock.enabled", false],
-        ["privacy.trackingprotection.enabled", false],
-        ["network.http.tailing.enabled", true],
-      ]);
-
-      await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      after(async () => {
+        await utils.clearPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName");
+      });
     });
 
   });

--- a/test/functional/1-telemetry.js
+++ b/test/functional/1-telemetry.js
@@ -20,7 +20,7 @@ describe("telemetry", function() {
     driver = await utils.setupWebdriver.promiseSetupDriver(
       utils.FIREFOX_PREFERENCES,
     );
-    await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "TPL0");
+    await utils.setPreference(driver, "extensions.fastblock-shield_mozilla_org.test.variationName", "TP");
     await utils.setupWebdriver.installAddon(driver);
   });
 

--- a/test/functional/utils.js
+++ b/test/functional/utils.js
@@ -72,6 +72,11 @@ async function clearPreference(driver, name) {
   await driver.executeScript(`Services.prefs.clearUserPref("${name}");`);
 }
 
+function prefHasUserValue(driver, name) {
+  driver.setContext(Context.CHROME);
+  return driver.executeScript(`return Services.prefs.prefHasUserValue("${name}");`);
+}
+
 async function openNewTab(driver) {
   driver.setContext(Context.CHROME);
   await driver.executeScript(`
@@ -97,6 +102,7 @@ module.exports = {
   setPreference,
   getPreference,
   clearPreference,
+  prefHasUserValue,
   openNewTab,
   removeCurrentTab,
 };


### PR DESCRIPTION
This commit:

- Closes #34 by reading pref values from their own config object (not a
JSON file, though).
- Closes #54 by setting prefs for hiding the TP and FB UIs when they
should not be exposed to users.
- Closes #76 by setting security.pki.distrust_ca_policy to 1 everywhere.
- Closes #77 by opting out of the study if the user has a modified pref
value (and also cleaning up prefs properly).

The only thing I'm slightly unsure about is #32, so we should discuss
this and potentially move to a follow-up. I'm generally a bit uncertain
about how the weighting works, but luckily that should be easy to
configure.