### PR TITLE
Make the reload survey apply to the document that was actually reloaded.

### DIFF
--- a/src/privileged/trackers/framescript.js
+++ b/src/privileged/trackers/framescript.js
@@ -1,29 +1,21 @@
-/* global ChromeUtils, content, docShell, sendAsyncMessage */
+/* global ChromeUtils, content, docShell, sendAsyncMessage, addMessageListener, removeMessageListener */
 
 // This will be reset on page unload.
 let telemetryData = {};
-let sentReload = false;
 
-const {classes: Cc, interfaces: Ci} = Components;
-const trackerListener = {
-  QueryInterface: ChromeUtils.generateQI(["nsIWebProgressListener", "nsISupportsWeakReference"]),
-  onSecurityChange(webProgress, request, state) {
-    // This is only to be able to show the "is this page broken?" dialog,
-    // we report the actual numbers of trackers later. We need to report this
-    // as soon as possible to be able to prompt the user. The remaining data
-    // is only sent at beforeunload.
-    if (!sentReload && telemetryData.pageReloaded && docShell.document.numTrackersFound > 0) {
-      sendAsyncMessage("reload-with-trackers", {hostname: telemetryData.hostname});
-      sentReload = true;
+const reloadListener = {
+  receiveMessage(message) {
+    if (message.name === "Browser:Reload") {
+      telemetryData.pageReloaded = true;
     }
   },
 };
 
-const filter = Cc["@mozilla.org/appshell/component/browser-status-filter;1"].createInstance(Ci.nsIWebProgress);
-filter.addProgressListener(trackerListener, Ci.nsIWebProgress.NOTIFY_ALL);
-const webProgress = docShell.QueryInterface(Ci.nsIInterfaceRequestor)
-  .getInterface(Ci.nsIWebProgress);
-webProgress.addProgressListener(filter, Ci.nsIWebProgress.NOTIFY_ALL);
+addMessageListener("Browser:Reload", reloadListener);
+
+addEventListener("unload", function() {
+  removeMessageListener("Browser:Reload", reloadListener);
+});
 
 // The global "load" and "unload" event listeners listen for lifetime
 // events of the framescript, hence we wait for a DOM window to appear
@@ -36,10 +28,11 @@ addEventListener("DOMContentLoaded", function(e) {
     return;
   }
 
-  telemetryData.hostname = content.location.hostname;
+  // We show the survey doorhanger on next page load, so
+  // let the background script know that some page loaded.
+  sendAsyncMessage("FastBlock:DOMContentLoaded", {});
 
-  const entryForReload = content.performance.getEntriesByType("navigation")[0];
-  telemetryData.pageReloaded = entryForReload.type === "reload";
+  telemetryData.hostname = content.location.hostname;
 
   // We use the "load" event to enter the performance data, because at
   // "load" +1 tick it will contain everything we need. This means some
@@ -81,7 +74,7 @@ addEventListener("DOMContentLoaded", function(e) {
     telemetryData.trackersFound = docShell.document.numTrackersFound;
     telemetryData.trackersBlocked = docShell.document.numTrackersBlocked;
 
-    sendAsyncMessage("beforeunload", {telemetryData});
+    sendAsyncMessage("FastBlock:beforeunload", {telemetryData});
   }, {once: true});
 
   content.window.addEventListener("unload", () => {
@@ -89,10 +82,12 @@ addEventListener("DOMContentLoaded", function(e) {
     if (docShell.document.numTrackersFound <= 0) {
       return;
     }
+    telemetryData.completeLocation = content.location.href;
+    telemetryData.trackersFound = docShell.document.numTrackersFound;
+    telemetryData.trackersBlocked = docShell.document.numTrackersBlocked;
 
-    sendAsyncMessage("unload", {});
+    sendAsyncMessage("FastBlock:unload", {telemetryData});
     telemetryData = {};
-    sentReload = false;
   }, {once: true});
 });
 

--- a/src/privileged/trackers/schema.json
+++ b/src/privileged/trackers/schema.json
@@ -22,11 +22,20 @@
         ]
       },
       {
+        "name": "onPageDOMContentLoaded",
+        "type": "function",
+        "description": "When the page has loaded the DOM.",
+        "parameters": [
+          {"type": "integer", "name": "tabId", "minimum": 0}
+        ]
+      },
+      {
         "name": "onPageUnload",
         "type": "function",
         "description": "When the page unloads.",
         "parameters": [
-          {"type": "integer", "name": "tabId", "minimum": 0}
+          {"type": "integer", "name": "tabId", "minimum": 0},
+          {"type": "object", "name": "data"}
         ]
       },
       {
@@ -35,15 +44,6 @@
         "description": "User reported breakage through the control center",
         "parameters": [
           {"type": "integer", "name": "tabId", "minimum": 0}
-        ]
-      },
-      {
-        "name": "onReloadWithTrackers",
-        "type": "function",
-        "description": "This is called when we find a page that was reloaded and has at least one tracker.",
-        "parameters": [
-          {"type": "integer", "name": "tabId", "minimum": 0},
-          {"type": "string", "name": "etld"}
         ]
       },
       {

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -53,6 +53,7 @@ window.TabRecords = {
     }
 
     tabInfo = {
+      payloadWaitingForSurvey: null,
       surveyShown: false,
       reloadCount: 0,
     };

--- a/test/functional/3-add-exception.js
+++ b/test/functional/3-add-exception.js
@@ -37,6 +37,11 @@ describe("add page exception button", function() {
   describe("records a user clicking the 'disable protection for this site' button", function() {
     let studyPings;
 
+    async function checkDoorhangerPresent() {
+      const result = await driver.findElements(By.id("fast-block-notification"));
+      return !!result.length;
+    }
+
     before(async () => {
 
       const time = Date.now();
@@ -51,8 +56,17 @@ describe("add page exception button", function() {
       // Locate and click the add exception button.
       const addExceptionButton = await driver.wait(until.elementLocated(By.id("tracking-action-unblock")), 1000);
       addExceptionButton.click();
-      // The page refreshes after clicking the add exception button, causing a ping to occur.
+      // The page refreshes after clicking the add exception button, causing a ping to occur or the
+      // survey doorhanger to be shown.
       await driver.sleep(DELAY);
+
+      // Interact with the doorhanger if it's showing.
+      const doorhangerPresent = checkDoorhangerPresent();
+      if (doorhangerPresent) {
+        await driver.executeScript(`document.getElementById("fast-block-notification").button.click()`);
+        await driver.sleep(DELAY);
+      }
+
       studyPings = await utils.telemetry.getShieldPingsAfterTimestamp(
         driver,
         time,

--- a/test/functional/5-reload-doorhanger.js
+++ b/test/functional/5-reload-doorhanger.js
@@ -14,7 +14,7 @@ const DELAY = process.env.DELAY ? parseInt(process.env.DELAY) : 500;
 
 describe("reload survey doorhanger", function() {
   // This gives Firefox time to start, and us a bit longer during some of the tests.
-  this.timeout(DELAY * 15);
+  this.timeout(DELAY * 30);
 
   let driver;
 
@@ -33,31 +33,33 @@ describe("reload survey doorhanger", function() {
 
   describe("shows a survey after reloading the page 6 times max", function() {
     let studyPings;
-    let tries = 0;
+    let reloads = 0;
 
     async function checkDoorhangerPresent() {
-      driver.setContext(Context.CHROME);
       const result = await driver.findElements(By.id("fast-block-notification"));
       return !!result.length;
     }
 
     before(async () => {
-      await utils.setPreference(driver, "privacy.trackingprotection.enabled", true);
       await driver.sleep(DELAY);
 
       const time = Date.now();
       driver.setContext(Context.CONTENT);
       await driver.get("https://itisatrap.org/firefox/its-a-tracker.html");
       await driver.sleep(DELAY);
-      while (tries++ < 6) {
-        const hasSeenDoorhanger = await checkDoorhangerPresent();
-        driver.setContext(Context.CONTENT);
-        await driver.navigate().refresh();
+      driver.setContext(Context.CHROME);
+      while (reloads++ < 6) {
+        await driver.executeScript(`document.getElementById("Browser:Reload").click()`);
         await driver.sleep(DELAY);
+        const hasSeenDoorhanger = await checkDoorhangerPresent();
         if (hasSeenDoorhanger) {
           break;
         }
       }
+
+      driver.setContext(Context.CONTENT);
+      await driver.get("https://example.com");
+      await driver.sleep(DELAY);
 
       studyPings = await utils.telemetry.getShieldPingsAfterTimestamp(
         driver,
@@ -66,35 +68,241 @@ describe("reload survey doorhanger", function() {
       studyPings = studyPings.filter(ping => ping.type === "shield-study-addon");
     });
 
-    it("shows the doorhanger after at most 6 tries", async () => {
-      assert.isAtMost(tries, 6, "Should have shown the doorhanger after at most 6 tries");
+    it("shows the doorhanger after at most 6 reloads", async () => {
+      assert.isAtMost(reloads, 6, "Should have shown the doorhanger after at most 6 reloads");
     });
 
-    it("has recorded one ping per reload", async () => {
-      assert.equal(studyPings.length, tries, "one shield telemetry ping per reload");
+    it("has recorded one ping per tracking page", async () => {
+      assert.equal(studyPings.length, reloads + 1, "one shield telemetry ping per tracking page load");
     });
 
     it("correctly records whether the page was reloaded", async () => {
       for (let i = 0; i < studyPings.length; i++) {
         const ping = studyPings[i];
         const attributes = ping.payload.data.attributes;
-        if (i === studyPings.length - 1) {
-          assert.equal(attributes.page_reloaded, "false", `page reloaded is false on ${i}`);
+        if (i === 0) {
+          assert.equal(attributes.page_reloaded, "false", `page reloaded is false on ${i}/${reloads}`);
         } else {
-          assert.equal(attributes.page_reloaded, "true", `page reloaded is true on ${i}`);
+          assert.equal(attributes.page_reloaded, "true", `page reloaded is true on ${i}/${reloads}`);
         }
 
-        if (i === 0) {
-          assert.equal(parseInt(attributes.page_reloaded_survey), 1, "page reloaded survey shown");
+        // The survey will be shown for the second-to-last document, because the last
+        // one is where the survey shows (and it gets discarded via navigation so it
+        // doesn't receive its own survey).
+        if (i === 1) {
+          assert.equal(parseInt(attributes.page_reloaded_survey), 1, `page reloaded survey shown on ${i}/${reloads}`);
         } else {
-          assert.equal(parseInt(attributes.page_reloaded_survey), 0, `page reloaded survey not shown on ${i}`);
+          assert.equal(parseInt(attributes.page_reloaded_survey), 0, `page reloaded survey not shown on ${i}/${reloads}`);
         }
       }
     });
+  });
 
-    after(async () => {
-      await utils.clearPreference(driver, "privacy.trackingprotection.enabled");
+  describe("disallows subsequently showing a survey on the same tab", function() {
+    let studyPings;
+    const reloads = 5;
+
+    before(async () => {
+      await driver.sleep(DELAY);
+
+      const time = Date.now();
+      driver.setContext(Context.CONTENT);
+      await driver.get("https://itisatrap.org/firefox/its-a-tracker.html");
+      await driver.sleep(DELAY);
+      driver.setContext(Context.CHROME);
+      for (let i = 0; i < reloads; i++) {
+        await driver.executeScript(`document.getElementById("Browser:Reload").click()`);
+        await driver.sleep(DELAY);
+      }
+
+      driver.setContext(Context.CONTENT);
+      await driver.get("https://example.com");
+      await driver.sleep(DELAY);
+
+      studyPings = await utils.telemetry.getShieldPingsAfterTimestamp(
+        driver,
+        time,
+      );
+      studyPings = studyPings.filter(ping => ping.type === "shield-study-addon");
+    });
+
+    it("has recorded one ping per tracking page", async () => {
+      assert.equal(studyPings.length, reloads + 1, "one shield telemetry ping per tracking page load");
+    });
+
+    it("correctly records whether the page was reloaded", async () => {
+      for (let i = 0; i < studyPings.length; i++) {
+        const ping = studyPings[i];
+        const attributes = ping.payload.data.attributes;
+
+        if (i === 0) {
+          assert.equal(attributes.page_reloaded, "false", `page reloaded is false on ${i}/${reloads}`);
+          assert.equal(parseInt(attributes.page_reloaded_survey), 0, `page reloaded survey not shown on ${i}/${reloads}`);
+        } else {
+          assert.equal(attributes.page_reloaded, "true", `page reloaded is true on ${i}/${reloads}`);
+          assert.equal(parseInt(attributes.page_reloaded_survey), 6, `page reloaded survey was not shown on ${i}/${reloads}`);
+        }
+      }
     });
   });
 
+  describe("records the correct survey response for yes", function() {
+    let studyPings;
+    const reloads = 8;
+    let doorhangerShownFor = Infinity;
+
+    async function checkDoorhangerPresent() {
+      const result = await driver.findElements(By.id("fast-block-notification"));
+      return !!result.length;
+    }
+
+    before(async () => {
+      // Reset the doorhanger shown state by restarting the browser.
+      driver.quit();
+      driver = await utils.setupWebdriver.promiseSetupDriver(
+        utils.FIREFOX_PREFERENCES,
+      );
+      await utils.setupWebdriver.installAddon(driver);
+      await driver.sleep(DELAY);
+
+      const time = Date.now();
+      driver.setContext(Context.CONTENT);
+      await driver.get("https://itisatrap.org/firefox/its-a-tracker.html");
+      await driver.sleep(DELAY);
+      driver.setContext(Context.CHROME);
+      for (let i = 0; i < reloads; i++) {
+        await driver.executeScript(`document.getElementById("Browser:Reload").click()`);
+        await driver.sleep(DELAY);
+        const hasSeenDoorhanger = await checkDoorhangerPresent();
+        if (hasSeenDoorhanger) {
+          doorhangerShownFor = i;
+          await driver.executeScript(`document.getElementById("fast-block-notification").button.click()`);
+        }
+      }
+
+      // Discard the final ping.
+      driver.setContext(Context.CONTENT);
+      await driver.get("https://example.com");
+      await driver.sleep(DELAY);
+
+      studyPings = await utils.telemetry.getShieldPingsAfterTimestamp(
+        driver,
+        time,
+      );
+      studyPings = studyPings.filter(ping => ping.type === "shield-study-addon");
+    });
+
+    it("shows the doorhanger after at most 6 reloads", async () => {
+      assert.isAtMost(doorhangerShownFor, 5, "Should have shown the doorhanger after at most 6 reloads");
+    });
+
+    it("has recorded one ping per tracking page", async () => {
+      assert.equal(studyPings.length, reloads + 1, "one shield telemetry ping per tracking page load");
+    });
+
+    it("correctly records whether the page was reloaded", async () => {
+      // The first pings are listed last in this array.
+      studyPings.reverse();
+
+      for (let i = 0; i < studyPings.length; i++) {
+        const ping = studyPings[i];
+        const attributes = ping.payload.data.attributes;
+        if (i === studyPings.length - 1) {
+          assert.equal(attributes.page_reloaded, "false", `page reloaded is false on ${i}/${reloads}`);
+        } else {
+          assert.equal(attributes.page_reloaded, "true", `page reloaded is true on ${i}/${reloads}`);
+        }
+
+        if (i === doorhangerShownFor) {
+          assert.equal(parseInt(attributes.page_reloaded_survey), 2, `page reloaded survey answered on ${i}/${reloads}`);
+        } else if (i === studyPings.length - 1) {
+          assert.equal(parseInt(attributes.page_reloaded_survey), 0, `page reloaded survey previously answered on ${i}/${reloads}`);
+        } else if (i > doorhangerShownFor) {
+          assert.equal(parseInt(attributes.page_reloaded_survey), 4, `page reloaded survey previously answered on ${i}/${reloads}`);
+        } else {
+          assert.equal(parseInt(attributes.page_reloaded_survey), 0, `page reloaded survey not shown on ${i}/${reloads}`);
+        }
+      }
+    });
+  });
+
+  describe("records the correct survey response for no", function() {
+    let studyPings;
+    const reloads = 8;
+    let doorhangerShownFor = Infinity;
+
+    async function checkDoorhangerPresent() {
+      const result = await driver.findElements(By.id("fast-block-notification"));
+      return !!result.length;
+    }
+
+    before(async () => {
+      // Reset the doorhanger shown state by restarting the browser.
+      driver.quit();
+      driver = await utils.setupWebdriver.promiseSetupDriver(
+        utils.FIREFOX_PREFERENCES,
+      );
+      await utils.setupWebdriver.installAddon(driver);
+      await driver.sleep(DELAY);
+
+      const time = Date.now();
+      driver.setContext(Context.CONTENT);
+      await driver.get("https://itisatrap.org/firefox/its-a-tracker.html");
+      await driver.sleep(DELAY);
+      driver.setContext(Context.CHROME);
+      for (let i = 0; i < reloads; i++) {
+        await driver.executeScript(`document.getElementById("Browser:Reload").click()`);
+        await driver.sleep(DELAY);
+        const hasSeenDoorhanger = await checkDoorhangerPresent();
+        if (hasSeenDoorhanger) {
+          doorhangerShownFor = i;
+          await driver.executeScript(`document.getElementById("fast-block-notification").secondaryButton.click()`);
+        }
+      }
+
+      // Discard the final ping.
+      driver.setContext(Context.CONTENT);
+      await driver.get("https://example.com");
+      await driver.sleep(DELAY);
+
+      studyPings = await utils.telemetry.getShieldPingsAfterTimestamp(
+        driver,
+        time,
+      );
+      studyPings = studyPings.filter(ping => ping.type === "shield-study-addon");
+    });
+
+    it("shows the doorhanger after at most 6 reloads", async () => {
+      assert.isAtMost(doorhangerShownFor, 5, "Should have shown the doorhanger after at most 6 reloads");
+    });
+
+    it("has recorded one ping per tracking page", async () => {
+      assert.equal(studyPings.length, reloads + 1, "one shield telemetry ping per tracking page load");
+    });
+
+    it("correctly records whether the page was reloaded", async () => {
+      // The first pings are listed last in this array.
+      studyPings.reverse();
+
+      for (let i = 0; i < studyPings.length; i++) {
+        const ping = studyPings[i];
+        const attributes = ping.payload.data.attributes;
+        if (i === studyPings.length - 1) {
+          assert.equal(attributes.page_reloaded, "false", `page reloaded is false on ${i}/${reloads}`);
+        } else {
+          assert.equal(attributes.page_reloaded, "true", `page reloaded is true on ${i}/${reloads}`);
+        }
+
+        if (i === doorhangerShownFor) {
+          assert.equal(parseInt(attributes.page_reloaded_survey), 3, `page reloaded survey answered on ${i}/${reloads}`);
+        } else if (i === studyPings.length - 1) {
+          assert.equal(parseInt(attributes.page_reloaded_survey), 0, `page reloaded survey previously answered on ${i}/${reloads}`);
+        } else if (i > doorhangerShownFor) {
+          assert.equal(parseInt(attributes.page_reloaded_survey), 5, `page reloaded survey previously answered on ${i}/${reloads}`);
+        } else {
+          assert.equal(parseInt(attributes.page_reloaded_survey), 0, `page reloaded survey not shown on ${i}/${reloads}`);
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
This introduces a new attribute on the tabInfo called
"payloadWaitingForSurvey", which keeps a payload that is currently held
back from sending because the user still needs to respond to the reload
survey.

During testing I have also found that the onBeforeUnload event tends to
be unreliable in certain cases (mostly when closing tabs), so this patch
further makes onUnload record data as well.. It was necessary to send some
of it along anyway, because the Browser:Reload event seems to arrive after
onbeforeunload and so we need to send it in onunload. Sorry for the
mess.